### PR TITLE
Fix?

### DIFF
--- a/pkgrename.c/include/terminal.h
+++ b/pkgrename.c/include/terminal.h
@@ -12,7 +12,6 @@ void reset_terminal();
 void raw_terminal();
 
 // Reads user input and stores it in buffer "string"
-void scan_string(char *string, size_t max_size, char *default_string,
-  char *(*f)());
+void scan_string(char *string, size_t max_size, char *default_string, char *(*f)(char *));
 
 #endif

--- a/pkgrename.c/src/releaselists.c
+++ b/pkgrename.c/src/releaselists.c
@@ -236,7 +236,6 @@ char *get_tag(char *string)
 // The buffer <tag> is stored in must be of length MAX_TAG_LEN.
 void replace_commas_in_tag(char *tag, const char *string)
 {
-//    size_t taglen = strlen(tag); // Initial length
     size_t stringlen = strlen(string);
 
     for (size_t i = 0; i < strlen(tag); i++) {

--- a/pkgrename.c/src/releaselists.c
+++ b/pkgrename.c/src/releaselists.c
@@ -236,7 +236,7 @@ char *get_tag(char *string)
 // The buffer <tag> is stored in must be of length MAX_TAG_LEN.
 void replace_commas_in_tag(char *tag, const char *string)
 {
-    size_t taglen = strlen(tag); // Initial length
+//    size_t taglen = strlen(tag); // Initial length
     size_t stringlen = strlen(string);
 
     for (size_t i = 0; i < strlen(tag); i++) {


### PR DESCRIPTION
It wouldn't compile on fedora 42 (GCC 15.2.1 Red Hat 15.2.1-4) unless these changes were made as it was throwing out these errors.
```
pkgrename.c git:(main) gcc -Wall -Wextra -pedantic pkgrename.c src/*.c -o pkgrename -lcurl -pthread -s -O3
pkgrename.c: In function ‘pkgrename’:
pkgrename.c:748:51: error: passing argument 4 of ‘scan_string’ from incompatible pointer type [-Wincompatible-pointer-types]
  748 |                 scan_string(tag, MAX_TAG_LEN, "", get_tag);
      |                                                   ^~~~~~~
      |                                                   |
      |                                                   char * (*)(char *)
In file included from pkgrename.c:16:
include/terminal.h:16:11: note: expected ‘char * (*)(void)’ but argument is of type ‘char * (*)(char *)’
   16 |   char *(*f)());
      |   ~~~~~~~~^~~~
In file included from pkgrename.c:13:
include/releaselists.h:12:7: note: ‘get_tag’ declared here
   12 | char *get_tag(char *string);
      |       ^~~~~~~
src/releaselists.c: In function ‘replace_commas_in_tag’:
src/releaselists.c:239:12: warning: unused variable ‘taglen’ [-Wunused-variable]
  239 |     size_t taglen = strlen(tag); // Initial length
      |            ^~~~~~
src/terminal.c:122:6: error: conflicting types for ‘scan_string’; have ‘void(char *, size_t,  char *, char * (*)(char *))’ {aka ‘void(char *, long unsigned int,  char *, char * (*)(char *))’}
  122 | void scan_string(char *string, size_t max_size, char *default_string, char *(*f)(char *))
      |      ^~~~~~~~~~~
In file included from src/terminal.c:2:
src/../include/terminal.h:15:6: note: previous declaration of ‘scan_string’ with type ‘void(char *, size_t,  char *, char * (*)(void))’ {aka ‘void(char *, long unsigned int,  char *, char * (*)(void))’}
   15 | void scan_string(char *string, size_t max_size, char *default_string,
      |      ^~~~~~~~~~~

```